### PR TITLE
Oxce3.5 plus proto erf plus

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -1367,19 +1367,19 @@ bool BattlescapeGame::checkReservedTU(BattleUnit *bu, int tu, int energy, bool j
     
     cost.updateTU();
     
-    // Check if Extended Reaction Fire is enabled and if so, choose whichever option takes more TUs.
-    // Only check if individual selection is made and is different from the general.
-    if (Options::extendedReactionFire && bu->getReservedAction() != BA_NONE && bu->getReservedAction() != cost.type)
-    {
-        BattleActionCost altCost = cost;
-        altCost.type = bu->getReservedAction();
-        altCost.updateTU();
-        if (altCost.Time - cost.Time > 0)
-        {
-            cost.type = altCost.type;
-            cost.updateTU();
-        }
-    }
+	// Check if Extended Reaction Fire is enabled and if so, choose whichever option takes more TUs.
+	// Only check if individual selection is made and is different from the general.
+	if (Options::extendedReactionFire && bu->getReservedAction() != BA_NONE && bu->getReservedAction() != cost.type)
+	{
+		BattleActionCost altCost = cost;
+		altCost.type = bu->getReservedAction();
+		altCost.updateTU();
+		if (altCost.Time - cost.Time > 0)
+		{
+			cost.type = altCost.type;
+			cost.updateTU();
+		}
+	}
 
 	// if the weapon has no autoshot, reserve TUs for snapshot
 	if (cost.Time == 0 && cost.type == BA_AUTOSHOT)
@@ -1489,7 +1489,6 @@ bool BattlescapeGame::handlePanickingUnit(BattleUnit *unit)
 			game->pushState(new InfoboxState(game->getLanguage()->getString("STR_HAS_GONE_BERSERK", unit->getGender()).arg(unit->getName(game->getLanguage()))));
 		}
 	}
-
 
 	int flee = RNG::generate(0,100);
 	BattleAction ba;
@@ -1926,7 +1925,7 @@ void BattlescapeGame::setTUReserved(BattleActionType tur)
  */
 void BattlescapeGame::setReservedAction(BattleActionType type)
 {
-    _save->getSelectedUnit()->reserveAction(type);
+	_save->getSelectedUnit()->reserveAction(type);
 }
 
 /**
@@ -2076,7 +2075,6 @@ Mod *BattlescapeGame::getMod()
 {
 	return _parentState->getGame()->getMod();
 }
-
 
 /**
  * Tries to find an item and pick it up if possible.

--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -1364,9 +1364,9 @@ bool BattlescapeGame::checkReservedTU(BattleUnit *bu, int tu, int energy, bool j
 		}
 		return cost.haveTU();
 	}
-    
-    cost.updateTU();
-    
+
+	cost.updateTU();
+
 	// Check if Extended Reaction Fire is enabled and if so, choose whichever option takes more TUs.
 	// Only check if individual selection is made and is different from the general.
 	if (Options::extendedReactionFire && bu->getReservedAction() != BA_NONE && bu->getReservedAction() != cost.type)
@@ -1397,14 +1397,14 @@ bool BattlescapeGame::checkReservedTU(BattleUnit *bu, int tu, int energy, bool j
 	// no aimed shot available? revert to none.
 	if (cost.Time == 0 && cost.type == BA_AIMEDSHOT)
 	{
-        if (tuKneel > 0)
-        {
-            cost.type = BA_NONE;
-        }
-        else
-        {
-            return true;
-        }
+		if (tuKneel > 0)
+		{
+			cost.type = BA_NONE;
+		}
+		else
+		{
+			return true;
+		}
 	}
 
 	cost.Time += tuKneel;
@@ -1422,31 +1422,31 @@ bool BattlescapeGame::checkReservedTU(BattleUnit *bu, int tu, int energy, bool j
 	{
 		if (!justChecking)
 		{
-            if (tuKneel)
-            {
-                if (cost.type == BA_NONE)
-                {
-                    _parentState->warning("STR_TIME_UNITS_RESERVED_FOR_KNEELING");
-                }
-                else
-                {
-                    _parentState->warning("STR_TIME_UNITS_RESERVED_FOR_KNEELING_AND_FIRING");
-                }
-            }
-            else
-            {
-                switch(cost.type)
-                {
-                    case BA_SNAPSHOT: _parentState->warning("STR_TIME_UNITS_RESERVED_FOR_SNAP_SHOT"); break;
-                    case BA_AUTOSHOT: _parentState->warning("STR_TIME_UNITS_RESERVED_FOR_AUTO_SHOT"); break;
-                    case BA_AIMEDSHOT: _parentState->warning("STR_TIME_UNITS_RESERVED_FOR_AIMED_SHOT"); break;
-                    default: ;
-                }
-            }
+			if (tuKneel)
+			{
+				if (cost.type == BA_NONE)
+				{
+					_parentState->warning("STR_TIME_UNITS_RESERVED_FOR_KNEELING");
+				}
+				else
+				{
+					_parentState->warning("STR_TIME_UNITS_RESERVED_FOR_KNEELING_AND_FIRING");
+				}
+			}
+			else
+			{
+				switch(cost.type)
+				{
+					case BA_SNAPSHOT: _parentState->warning("STR_TIME_UNITS_RESERVED_FOR_SNAP_SHOT"); break;
+					case BA_AUTOSHOT: _parentState->warning("STR_TIME_UNITS_RESERVED_FOR_AUTO_SHOT"); break;
+					case BA_AIMEDSHOT: _parentState->warning("STR_TIME_UNITS_RESERVED_FOR_AIMED_SHOT"); break;
+					default: ;
+				}
+			}
 		}
 		return false;
 	}
-
+	
 	return true;
 }
 

--- a/src/Battlescape/BattlescapeGame.h
+++ b/src/Battlescape/BattlescapeGame.h
@@ -193,9 +193,9 @@ public:
 	void requestEndTurn(bool askForConfirmation);
 	/// Sets the TU reserved type.
 	void setTUReserved(BattleActionType tur);
-    /// Sets the reserved action type.
+	/// Sets the reserved action type.
 	void setReservedAction(BattleActionType type);
-    /// Sets up the cursor taking into account the action.
+	/// Sets up the cursor taking into account the action.
 	void setupCursor();
 	/// Gets the map.
 	Map *getMap();

--- a/src/Battlescape/BattlescapeGame.h
+++ b/src/Battlescape/BattlescapeGame.h
@@ -194,7 +194,7 @@ public:
 	/// Sets the TU reserved type.
 	void setTUReserved(BattleActionType tur);
     /// Sets the reserved action type.
-    void setReservedAction(BattleActionType type);
+	void setReservedAction(BattleActionType type);
     /// Sets up the cursor taking into account the action.
 	void setupCursor();
 	/// Gets the map.

--- a/src/Battlescape/BattlescapeGame.h
+++ b/src/Battlescape/BattlescapeGame.h
@@ -193,7 +193,9 @@ public:
 	void requestEndTurn(bool askForConfirmation);
 	/// Sets the TU reserved type.
 	void setTUReserved(BattleActionType tur);
-	/// Sets up the cursor taking into account the action.
+    /// Sets the reserved action type.
+    void setReservedAction(BattleActionType type);
+    /// Sets up the cursor taking into account the action.
 	void setupCursor();
 	/// Gets the map.
 	Map *getMap();

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -423,28 +423,28 @@ BattlescapeState::BattlescapeState() : _reserve(0), _select(0), _firstInit(true)
 	_btnRightHandItem->onMouseOut((ActionHandler)&BattlescapeState::txtTooltipOut);
 
 	_btnReserveNone->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick);
-    _btnReserveNone->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
+	_btnReserveNone->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
 	_btnReserveNone->onKeyboardPress((ActionHandler)&BattlescapeState::btnReserveClick, Options::keyBattleReserveNone);
 	_btnReserveNone->setTooltip("STR_DONT_RESERVE_TIME_UNITS");
 	_btnReserveNone->onMouseIn((ActionHandler)&BattlescapeState::txtTooltipIn);
 	_btnReserveNone->onMouseOut((ActionHandler)&BattlescapeState::txtTooltipOut);
 
 	_btnReserveSnap->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick);
-    _btnReserveSnap->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
+	_btnReserveSnap->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
 	_btnReserveSnap->onKeyboardPress((ActionHandler)&BattlescapeState::btnReserveClick, Options::keyBattleReserveSnap);
 	_btnReserveSnap->setTooltip("STR_RESERVE_TIME_UNITS_FOR_SNAP_SHOT");
 	_btnReserveSnap->onMouseIn((ActionHandler)&BattlescapeState::txtTooltipIn);
 	_btnReserveSnap->onMouseOut((ActionHandler)&BattlescapeState::txtTooltipOut);
 
 	_btnReserveAimed->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick);
-    _btnReserveAimed->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
+	_btnReserveAimed->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
 	_btnReserveAimed->onKeyboardPress((ActionHandler)&BattlescapeState::btnReserveClick, Options::keyBattleReserveAimed);
 	_btnReserveAimed->setTooltip("STR_RESERVE_TIME_UNITS_FOR_AIMED_SHOT");
 	_btnReserveAimed->onMouseIn((ActionHandler)&BattlescapeState::txtTooltipIn);
 	_btnReserveAimed->onMouseOut((ActionHandler)&BattlescapeState::txtTooltipOut);
 
 	_btnReserveAuto->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick);
-    _btnReserveAuto->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
+	_btnReserveAuto->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
 	_btnReserveAuto->onKeyboardPress((ActionHandler)&BattlescapeState::btnReserveClick, Options::keyBattleReserveAuto);
 	_btnReserveAuto->setTooltip("STR_RESERVE_TIME_UNITS_FOR_AUTO_SHOT");
 	_btnReserveAuto->onMouseIn((ActionHandler)&BattlescapeState::txtTooltipIn);
@@ -530,6 +530,11 @@ BattlescapeState::BattlescapeState() : _reserve(0), _select(0), _firstInit(true)
     _btnReserveSnap->setGroupSelected(&_select);
     _btnReserveAimed->setGroupSelected(&_select);
     _btnReserveAuto->setGroupSelected(&_select);
+
+	_btnReserveNone->setGroupSelected(&_select);
+	_btnReserveSnap->setGroupSelected(&_select);
+	_btnReserveAimed->setGroupSelected(&_select);
+	_btnReserveAuto->setGroupSelected(&_select);
 
 	// Set music
 	if (_save->getMusic() == "")
@@ -633,6 +638,25 @@ void BattlescapeState::init()
         _btnReserveNone->toggleSelected(true);
         break;
     }
+	switch(_save->getSelectedUnit()->getReservedAction())
+	{
+	case BA_SNAPSHOT:
+		_select = _btnReserveSnap;
+		_btnReserveSnap->toggleSelected(true);
+		break;
+	case BA_AUTOSHOT:
+		_select = _btnReserveAuto;
+		_btnReserveAuto->toggleSelected(true);
+		break;
+	case BA_AIMEDSHOT:
+		_select = _btnReserveAimed;
+		_btnReserveAimed->toggleSelected(true);
+		break;
+	default:
+		_select = _btnReserveNone;
+		_btnReserveNone->toggleSelected(true);
+		break;
+	}
 	if (_firstInit && playableUnitSelected())
 	{
 		_battleGame->setupCursor();
@@ -1005,6 +1029,10 @@ void BattlescapeState::toggleReserveActionButton(BattleUnit* unit)
     _btnReserveAuto->toggleSelected(unit->getReservedAction() == BA_AUTOSHOT);
     _btnReserveAimed->toggleSelected(unit->getReservedAction() == BA_AIMEDSHOT);
     _btnReserveNone->toggleSelected(unit->getReservedAction() == BA_NONE);
+	_btnReserveSnap->toggleSelected(unit->getReservedAction() == BA_SNAPSHOT);
+	_btnReserveAuto->toggleSelected(unit->getReservedAction() == BA_AUTOSHOT);
+	_btnReserveAimed->toggleSelected(unit->getReservedAction() == BA_AIMEDSHOT);
+	_btnReserveNone->toggleSelected(unit->getReservedAction() == BA_NONE);
 }
 
 void BattlescapeState::toggleKneelButton(BattleUnit* unit)
@@ -1411,6 +1439,63 @@ void BattlescapeState::btnReserveClick(Action *action)
             }
         }
     }
+		if (action->getDetails()->button.button == SDL_BUTTON_LEFT) {
+			ev.type = SDL_MOUSEBUTTONDOWN;
+			ev.button.button = SDL_BUTTON_LEFT;
+			Action a = Action(&ev, 0.0, 0.0, 0, 0);
+			action->getSender()->mousePress(&a, this);
+			
+			if (_reserve == _btnReserveNone)
+				_battleGame->setTUReserved(BA_NONE);
+			else if (_reserve == _btnReserveSnap)
+				_battleGame->setTUReserved(BA_SNAPSHOT);
+			else if (_reserve == _btnReserveAimed)
+				_battleGame->setTUReserved(BA_AIMEDSHOT);
+			else if (_reserve == _btnReserveAuto)
+				_battleGame->setTUReserved(BA_AUTOSHOT);
+			
+			// update any path preview
+			if (_battleGame->getPathfinding()->isPathPreviewed())
+			{
+				_battleGame->getPathfinding()->removePreview();
+				_battleGame->getPathfinding()->previewPath();
+			}
+		}
+		
+		// If Extended Reaction Fire is enabled, process right button click.
+		if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
+		{
+			ev.type = SDL_MOUSEBUTTONDOWN;
+			ev.button.button = SDL_BUTTON_RIGHT;
+			Action a = Action(&ev, 0.0, 0.0, 0, 0);
+			action->getSender()->mousePress(&a, this);
+			
+			if (Options::extendedReactionFire)
+			{
+				if (_select == _btnReserveNone)
+					_battleGame->setReservedAction(BA_NONE);
+				else if (_select == _btnReserveSnap)
+					_battleGame->setReservedAction(BA_SNAPSHOT);
+				else if (_select == _btnReserveAuto)
+					_battleGame->setReservedAction(BA_AUTOSHOT);
+				else if (_select == _btnReserveAimed)
+					_battleGame->setReservedAction(BA_AIMEDSHOT);
+				
+				toggleReserveActionButton(_save->getSelectedUnit());
+				
+				// update any path preview
+				if (_battleGame->getPathfinding()->isPathPreviewed())
+				{
+					_battleGame->getPathfinding()->removePreview();
+					_battleGame->getPathfinding()->previewPath();
+				}
+			}
+			else
+			{
+				_battleGame->setReservedAction(BA_NONE);
+			}
+		}
+	}
 }
 
 /**
@@ -2977,7 +3062,6 @@ void BattlescapeState::resize(int &dX, int &dY)
 			(*i)->setX((*i)->getX() + dX);
 		}
 	}
-
 }
 
 /**

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -525,11 +525,6 @@ BattlescapeState::BattlescapeState() : _reserve(0), _select(0), _firstInit(true)
 	_btnReserveSnap->setGroup(&_reserve);
 	_btnReserveAimed->setGroup(&_reserve);
 	_btnReserveAuto->setGroup(&_reserve);
-    
-    _btnReserveNone->setGroupSelected(&_select);
-    _btnReserveSnap->setGroupSelected(&_select);
-    _btnReserveAimed->setGroupSelected(&_select);
-    _btnReserveAuto->setGroupSelected(&_select);
 
 	_btnReserveNone->setGroupSelected(&_select);
 	_btnReserveSnap->setGroupSelected(&_select);
@@ -619,25 +614,6 @@ void BattlescapeState::init()
 		_reserve = _btnReserveNone;
 		break;
 	}
-    switch(_save->getSelectedUnit()->getReservedAction())
-    {
-    case BA_SNAPSHOT:
-        _select = _btnReserveSnap;
-        _btnReserveSnap->toggleSelected(true);
-        break;
-    case BA_AUTOSHOT:
-        _select = _btnReserveAuto;
-        _btnReserveAuto->toggleSelected(true);
-        break;
-    case BA_AIMEDSHOT:
-        _select = _btnReserveAimed;
-        _btnReserveAimed->toggleSelected(true);
-        break;
-    default:
-        _select = _btnReserveNone;
-        _btnReserveNone->toggleSelected(true);
-        break;
-    }
 	switch(_save->getSelectedUnit()->getReservedAction())
 	{
 	case BA_SNAPSHOT:
@@ -1025,10 +1001,6 @@ void BattlescapeState::btnShowMapClick(Action *)
  */
 void BattlescapeState::toggleReserveActionButton(BattleUnit* unit)
 {
-    _btnReserveSnap->toggleSelected(unit->getReservedAction() == BA_SNAPSHOT);
-    _btnReserveAuto->toggleSelected(unit->getReservedAction() == BA_AUTOSHOT);
-    _btnReserveAimed->toggleSelected(unit->getReservedAction() == BA_AIMEDSHOT);
-    _btnReserveNone->toggleSelected(unit->getReservedAction() == BA_NONE);
 	_btnReserveSnap->toggleSelected(unit->getReservedAction() == BA_SNAPSHOT);
 	_btnReserveAuto->toggleSelected(unit->getReservedAction() == BA_AUTOSHOT);
 	_btnReserveAimed->toggleSelected(unit->getReservedAction() == BA_AIMEDSHOT);
@@ -1382,63 +1354,6 @@ void BattlescapeState::btnReserveClick(Action *action)
 	if (allowButtons())
 	{
 		SDL_Event ev;
-        if (action->getDetails()->button.button == SDL_BUTTON_LEFT) {
-            ev.type = SDL_MOUSEBUTTONDOWN;
-            ev.button.button = SDL_BUTTON_LEFT;
-            Action a = Action(&ev, 0.0, 0.0, 0, 0);
-            action->getSender()->mousePress(&a, this);
-            
-            if (_reserve == _btnReserveNone)
-                _battleGame->setTUReserved(BA_NONE);
-            else if (_reserve == _btnReserveSnap)
-                _battleGame->setTUReserved(BA_SNAPSHOT);
-            else if (_reserve == _btnReserveAimed)
-                _battleGame->setTUReserved(BA_AIMEDSHOT);
-            else if (_reserve == _btnReserveAuto)
-                _battleGame->setTUReserved(BA_AUTOSHOT);
-            
-            // update any path preview
-            if (_battleGame->getPathfinding()->isPathPreviewed())
-            {
-                _battleGame->getPathfinding()->removePreview();
-                _battleGame->getPathfinding()->previewPath();
-            }
-        }
-        
-        // If Extended Reaction Fire is enabled, process right button click.
-        if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
-        {
-            ev.type = SDL_MOUSEBUTTONDOWN;
-            ev.button.button = SDL_BUTTON_RIGHT;
-            Action a = Action(&ev, 0.0, 0.0, 0, 0);
-            action->getSender()->mousePress(&a, this);
-            
-            if (Options::extendedReactionFire)
-            {
-                if (_select == _btnReserveNone)
-                    _battleGame->setReservedAction(BA_NONE);
-                else if (_select == _btnReserveSnap)
-                    _battleGame->setReservedAction(BA_SNAPSHOT);
-                else if (_select == _btnReserveAuto)
-                    _battleGame->setReservedAction(BA_AUTOSHOT);
-                else if (_select == _btnReserveAimed)
-                    _battleGame->setReservedAction(BA_AIMEDSHOT);
-                
-                toggleReserveActionButton(_save->getSelectedUnit());
-                
-                // update any path preview
-                if (_battleGame->getPathfinding()->isPathPreviewed())
-                {
-                    _battleGame->getPathfinding()->removePreview();
-                    _battleGame->getPathfinding()->previewPath();
-                }
-            }
-            else
-            {
-                _battleGame->setReservedAction(BA_NONE);
-            }
-        }
-    }
 		if (action->getDetails()->button.button == SDL_BUTTON_LEFT) {
 			ev.type = SDL_MOUSEBUTTONDOWN;
 			ev.button.button = SDL_BUTTON_LEFT;

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -86,7 +86,7 @@ namespace OpenXcom
  * Initializes all the elements in the Battlescape screen.
  * @param game Pointer to the core game.
  */
-BattlescapeState::BattlescapeState() : _reserve(0), _firstInit(true), _isMouseScrolling(false), _isMouseScrolled(false), _xBeforeMouseScrolling(0), _yBeforeMouseScrolling(0), _totalMouseMoveX(0), _totalMouseMoveY(0), _mouseMovedOverThreshold(0), _mouseOverIcons(false), _autosave(false), _animFrame(0), _numberOfDirectlyVisibleUnits(0), _numberOfEnemiesTotal(0), _numberOfEnemiesTotalPlusWounded(0)
+BattlescapeState::BattlescapeState() : _reserve(0), _select(0), _firstInit(true), _isMouseScrolling(false), _isMouseScrolled(false), _xBeforeMouseScrolling(0), _yBeforeMouseScrolling(0), _totalMouseMoveX(0), _totalMouseMoveY(0), _mouseMovedOverThreshold(0), _mouseOverIcons(false), _autosave(false), _animFrame(0), _numberOfDirectlyVisibleUnits(0), _numberOfEnemiesTotal(0), _numberOfEnemiesTotalPlusWounded(0)
 {
 	std::fill_n(_visibleUnit, 10, (BattleUnit*)(0));
 
@@ -423,24 +423,28 @@ BattlescapeState::BattlescapeState() : _reserve(0), _firstInit(true), _isMouseSc
 	_btnRightHandItem->onMouseOut((ActionHandler)&BattlescapeState::txtTooltipOut);
 
 	_btnReserveNone->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick);
+    _btnReserveNone->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
 	_btnReserveNone->onKeyboardPress((ActionHandler)&BattlescapeState::btnReserveClick, Options::keyBattleReserveNone);
 	_btnReserveNone->setTooltip("STR_DONT_RESERVE_TIME_UNITS");
 	_btnReserveNone->onMouseIn((ActionHandler)&BattlescapeState::txtTooltipIn);
 	_btnReserveNone->onMouseOut((ActionHandler)&BattlescapeState::txtTooltipOut);
 
 	_btnReserveSnap->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick);
+    _btnReserveSnap->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
 	_btnReserveSnap->onKeyboardPress((ActionHandler)&BattlescapeState::btnReserveClick, Options::keyBattleReserveSnap);
 	_btnReserveSnap->setTooltip("STR_RESERVE_TIME_UNITS_FOR_SNAP_SHOT");
 	_btnReserveSnap->onMouseIn((ActionHandler)&BattlescapeState::txtTooltipIn);
 	_btnReserveSnap->onMouseOut((ActionHandler)&BattlescapeState::txtTooltipOut);
 
 	_btnReserveAimed->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick);
+    _btnReserveAimed->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
 	_btnReserveAimed->onKeyboardPress((ActionHandler)&BattlescapeState::btnReserveClick, Options::keyBattleReserveAimed);
 	_btnReserveAimed->setTooltip("STR_RESERVE_TIME_UNITS_FOR_AIMED_SHOT");
 	_btnReserveAimed->onMouseIn((ActionHandler)&BattlescapeState::txtTooltipIn);
 	_btnReserveAimed->onMouseOut((ActionHandler)&BattlescapeState::txtTooltipOut);
 
 	_btnReserveAuto->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick);
+    _btnReserveAuto->onMouseClick((ActionHandler)&BattlescapeState::btnReserveClick, SDL_BUTTON_RIGHT);
 	_btnReserveAuto->onKeyboardPress((ActionHandler)&BattlescapeState::btnReserveClick, Options::keyBattleReserveAuto);
 	_btnReserveAuto->setTooltip("STR_RESERVE_TIME_UNITS_FOR_AUTO_SHOT");
 	_btnReserveAuto->onMouseIn((ActionHandler)&BattlescapeState::txtTooltipIn);
@@ -463,6 +467,7 @@ BattlescapeState::BattlescapeState() : _reserve(0), _firstInit(true), _isMouseSc
 	// shortcuts without a specific button
 	_btnStats->onKeyboardPress((ActionHandler)&BattlescapeState::btnReloadClick, Options::keyBattleReload);
 	_btnStats->onKeyboardPress((ActionHandler)&BattlescapeState::btnPersonalLightingClick, Options::keyBattlePersonalLighting);
+
 	_btnStats->onKeyboardPress((ActionHandler)&BattlescapeState::btnNightVisionClick, Options::keyNightVisionToggle);
 	if (Options::autoNightVision)
 	{
@@ -520,6 +525,11 @@ BattlescapeState::BattlescapeState() : _reserve(0), _firstInit(true), _isMouseSc
 	_btnReserveSnap->setGroup(&_reserve);
 	_btnReserveAimed->setGroup(&_reserve);
 	_btnReserveAuto->setGroup(&_reserve);
+    
+    _btnReserveNone->setGroupSelected(&_select);
+    _btnReserveSnap->setGroupSelected(&_select);
+    _btnReserveAimed->setGroupSelected(&_select);
+    _btnReserveAuto->setGroupSelected(&_select);
 
 	// Set music
 	if (_save->getMusic() == "")
@@ -604,6 +614,25 @@ void BattlescapeState::init()
 		_reserve = _btnReserveNone;
 		break;
 	}
+    switch(_save->getSelectedUnit()->getReservedAction())
+    {
+    case BA_SNAPSHOT:
+        _select = _btnReserveSnap;
+        _btnReserveSnap->toggleSelected(true);
+        break;
+    case BA_AUTOSHOT:
+        _select = _btnReserveAuto;
+        _btnReserveAuto->toggleSelected(true);
+        break;
+    case BA_AIMEDSHOT:
+        _select = _btnReserveAimed;
+        _btnReserveAimed->toggleSelected(true);
+        break;
+    default:
+        _select = _btnReserveNone;
+        _btnReserveNone->toggleSelected(true);
+        break;
+    }
 	if (_firstInit && playableUnitSelected())
 	{
 		_battleGame->setupCursor();
@@ -613,6 +642,10 @@ void BattlescapeState::init()
 		_btnReserveSnap->setGroup(&_reserve);
 		_btnReserveAimed->setGroup(&_reserve);
 		_btnReserveAuto->setGroup(&_reserve);
+        _btnReserveNone->setGroupSelected(&_select);
+        _btnReserveSnap->setGroupSelected(&_select);
+        _btnReserveAimed->setGroupSelected(&_select);
+        _btnReserveAuto->setGroupSelected(&_select);
 	}
 	_txtTooltip->setText(L"");
 	_btnReserveKneel->toggle(_save->getKneelReserved());
@@ -845,7 +878,13 @@ void BattlescapeState::mapClick(Action *action)
 	// right-click aborts walking state
 	if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 	{
-		if (_battleGame->cancelCurrentAction())
+        // Avoid aborting / removing preview when right clicking reserve buttons when Extended Reaction Fire is enabled
+        if ((!Options::extendedReactionFire ||
+             _btnReserveNone->getX() > action->getAbsoluteXMouse() ||
+              action->getAbsoluteXMouse() > _btnReserveNone->getX() + 2 * _btnReserveNone->getWidth() ||
+              _btnReserveNone->getY() > action->getAbsoluteYMouse() ||
+              action->getAbsoluteYMouse() > (_btnReserveNone->getY() + 2 * _btnReserveNone->getHeight())) &&
+             _battleGame->cancelCurrentAction())
 		{
 			return;
 		}
@@ -955,6 +994,17 @@ void BattlescapeState::btnShowMapClick(Action *)
 	//MiniMapState
 	if (allowButtons())
 		_game->pushState (new MiniMapState (_map->getCamera(), _save));
+}
+/**
+ * Toggles the reserve TUs button for the individual choice.
+ * @param unit Pointer to a unit.
+ */
+void BattlescapeState::toggleReserveActionButton(BattleUnit* unit)
+{
+    _btnReserveSnap->toggleSelected(unit->getReservedAction() == BA_SNAPSHOT);
+    _btnReserveAuto->toggleSelected(unit->getReservedAction() == BA_AUTOSHOT);
+    _btnReserveAimed->toggleSelected(unit->getReservedAction() == BA_AIMEDSHOT);
+    _btnReserveNone->toggleSelected(unit->getReservedAction() == BA_NONE);
 }
 
 void BattlescapeState::toggleKneelButton(BattleUnit* unit)
@@ -1304,27 +1354,63 @@ void BattlescapeState::btnReserveClick(Action *action)
 	if (allowButtons())
 	{
 		SDL_Event ev;
-		ev.type = SDL_MOUSEBUTTONDOWN;
-		ev.button.button = SDL_BUTTON_LEFT;
-		Action a = Action(&ev, 0.0, 0.0, 0, 0);
-		action->getSender()->mousePress(&a, this);
-
-		if (_reserve == _btnReserveNone)
-			_battleGame->setTUReserved(BA_NONE);
-		else if (_reserve == _btnReserveSnap)
-			_battleGame->setTUReserved(BA_SNAPSHOT);
-		else if (_reserve == _btnReserveAimed)
-			_battleGame->setTUReserved(BA_AIMEDSHOT);
-		else if (_reserve == _btnReserveAuto)
-			_battleGame->setTUReserved(BA_AUTOSHOT);
-
-		// update any path preview
-		if (_battleGame->getPathfinding()->isPathPreviewed())
-		{
-			_battleGame->getPathfinding()->removePreview();
-			_battleGame->getPathfinding()->previewPath();
-		}
-	}
+        if (action->getDetails()->button.button == SDL_BUTTON_LEFT) {
+            ev.type = SDL_MOUSEBUTTONDOWN;
+            ev.button.button = SDL_BUTTON_LEFT;
+            Action a = Action(&ev, 0.0, 0.0, 0, 0);
+            action->getSender()->mousePress(&a, this);
+            
+            if (_reserve == _btnReserveNone)
+                _battleGame->setTUReserved(BA_NONE);
+            else if (_reserve == _btnReserveSnap)
+                _battleGame->setTUReserved(BA_SNAPSHOT);
+            else if (_reserve == _btnReserveAimed)
+                _battleGame->setTUReserved(BA_AIMEDSHOT);
+            else if (_reserve == _btnReserveAuto)
+                _battleGame->setTUReserved(BA_AUTOSHOT);
+            
+            // update any path preview
+            if (_battleGame->getPathfinding()->isPathPreviewed())
+            {
+                _battleGame->getPathfinding()->removePreview();
+                _battleGame->getPathfinding()->previewPath();
+            }
+        }
+        
+        // If Extended Reaction Fire is enabled, process right button click.
+        if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
+        {
+            ev.type = SDL_MOUSEBUTTONDOWN;
+            ev.button.button = SDL_BUTTON_RIGHT;
+            Action a = Action(&ev, 0.0, 0.0, 0, 0);
+            action->getSender()->mousePress(&a, this);
+            
+            if (Options::extendedReactionFire)
+            {
+                if (_select == _btnReserveNone)
+                    _battleGame->setReservedAction(BA_NONE);
+                else if (_select == _btnReserveSnap)
+                    _battleGame->setReservedAction(BA_SNAPSHOT);
+                else if (_select == _btnReserveAuto)
+                    _battleGame->setReservedAction(BA_AUTOSHOT);
+                else if (_select == _btnReserveAimed)
+                    _battleGame->setReservedAction(BA_AIMEDSHOT);
+                
+                toggleReserveActionButton(_save->getSelectedUnit());
+                
+                // update any path preview
+                if (_battleGame->getPathfinding()->isPathPreviewed())
+                {
+                    _battleGame->getPathfinding()->removePreview();
+                    _battleGame->getPathfinding()->previewPath();
+                }
+            }
+            else
+            {
+                _battleGame->setReservedAction(BA_NONE);
+            }
+        }
+    }
 }
 
 /**
@@ -1547,7 +1633,8 @@ void BattlescapeState::updateSoldierInfo()
 	_barMorale->setValue(battleUnit->getMorale());
 
 	toggleKneelButton(battleUnit);
-
+    toggleReserveActionButton(battleUnit);
+    
 	// FIXME: Meridian: extract into function later like Yankes did (merge conflict)
 	//drawHandsItems();
 

--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -52,7 +52,7 @@ private:
 	Map *_map;
 	BattlescapeButton *_btnUnitUp, *_btnUnitDown, *_btnMapUp, *_btnMapDown, *_btnShowMap, *_btnKneel;
 	BattlescapeButton *_btnInventory, *_btnCenter, *_btnNextSoldier, *_btnNextStop, *_btnShowLayers, *_btnHelp;
-	BattlescapeButton *_btnEndTurn, *_btnAbort, *_btnLaunch, *_btnPsi, *_reserve;
+	BattlescapeButton *_btnEndTurn, *_btnAbort, *_btnLaunch, *_btnPsi, *_reserve, *_select;
 	InteractiveSurface *_btnStats;
 	BattlescapeButton *_btnReserveNone, *_btnReserveSnap, *_btnReserveAimed, *_btnReserveAuto, *_btnReserveKneel, *_btnZeroTUs;
 	InteractiveSurface *_btnLeftHandItem, *_btnRightHandItem;
@@ -99,6 +99,8 @@ private:
 	void drawPrimers();
 	/// Shows the unit kneel state.
 	void toggleKneelButton(BattleUnit* unit);
+    /// Shows the unit reserve TU state.
+    void toggleReserveActionButton(BattleUnit* unit);
 public:
 	/// Selects the next soldier.
 	void selectNextPlayerUnit(bool checkReselect = false, bool setReselect = false, bool checkInventory = false);

--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -99,8 +99,8 @@ private:
 	void drawPrimers();
 	/// Shows the unit kneel state.
 	void toggleKneelButton(BattleUnit* unit);
-    /// Shows the unit reserve TU state.
-    void toggleReserveActionButton(BattleUnit* unit);
+	/// Shows the unit reserve TU state.
+	void toggleReserveActionButton(BattleUnit* unit);
 public:
 	/// Selects the next soldier.
 	void selectNextPlayerUnit(bool checkReselect = false, bool setReselect = false, bool checkInventory = false);

--- a/src/Battlescape/Pathfinding.cpp
+++ b/src/Battlescape/Pathfinding.cpp
@@ -895,7 +895,7 @@ bool Pathfinding::previewPath(bool bRemove)
 	int size = _unit->getArmor()->getSize() - 1;
 	int total = _unit->isKneeled() ? 8 : 0;
 	bool switchBack = false;
-    // FIXME: Is ERF check required? What about the check whether the faction is alien?
+	// FIXME: Is ERF check required? What about the check whether the faction is alien?
 	if (_save->getBattleGame()->getReservedAction() == BA_NONE && (!Options::extendedReactionFire || _unit->getReservedAction() == BA_NONE || _unit->getFaction() != FACTION_PLAYER))
 	{
 		switchBack = true;

--- a/src/Battlescape/Pathfinding.cpp
+++ b/src/Battlescape/Pathfinding.cpp
@@ -895,7 +895,8 @@ bool Pathfinding::previewPath(bool bRemove)
 	int size = _unit->getArmor()->getSize() - 1;
 	int total = _unit->isKneeled() ? 8 : 0;
 	bool switchBack = false;
-	if (_save->getBattleGame()->getReservedAction() == BA_NONE)
+    // FIXME: Is ERF check required? What about the check whether the faction is alien?
+    if (_save->getBattleGame()->getReservedAction() == BA_NONE && (!Options::extendedReactionFire || _unit->getReservedAction() == BA_NONE || _unit->getFaction() != FACTION_PLAYER))
 	{
 		switchBack = true;
 		_save->getBattleGame()->setTUReserved(BA_AUTOSHOT);

--- a/src/Battlescape/Pathfinding.cpp
+++ b/src/Battlescape/Pathfinding.cpp
@@ -896,7 +896,7 @@ bool Pathfinding::previewPath(bool bRemove)
 	int total = _unit->isKneeled() ? 8 : 0;
 	bool switchBack = false;
     // FIXME: Is ERF check required? What about the check whether the faction is alien?
-    if (_save->getBattleGame()->getReservedAction() == BA_NONE && (!Options::extendedReactionFire || _unit->getReservedAction() == BA_NONE || _unit->getFaction() != FACTION_PLAYER))
+	if (_save->getBattleGame()->getReservedAction() == BA_NONE && (!Options::extendedReactionFire || _unit->getReservedAction() == BA_NONE || _unit->getFaction() != FACTION_PLAYER))
 	{
 		switchBack = true;
 		_save->getBattleGame()->setTUReserved(BA_AUTOSHOT);

--- a/src/Interface/BattlescapeButton.cpp
+++ b/src/Interface/BattlescapeButton.cpp
@@ -203,7 +203,7 @@ void BattlescapeButton::initSurfaces()
 	delete _altSurfaceInvSel;
 	_altSurfaceInvSel = new Surface(_surface->w, _surface->h, _x, _y); // For selected and inverted reserve button
 	_altSurfaceInvSel->setPalette(getPalette());
-
+	
 	// Lock the surface
 	_altSurface->lock();
 	_altSurfaceSel->lock();
@@ -276,7 +276,7 @@ void BattlescapeButton::initSurfaces()
 			}
 		}
 	}
-
+	
 	// Unlock the surface
 	_altSurface->unlock();
 	_altSurfaceSel->unlock();

--- a/src/Interface/BattlescapeButton.h
+++ b/src/Interface/BattlescapeButton.h
@@ -59,7 +59,7 @@ public:
 	/// Invert a button explicitly either ON or OFF.
 	void toggle(bool invert);
     /// Toggle selected either ON or OFF (Extended Reaction Fire, reaction button).
-    void toggleSelected(bool select);
+	void toggleSelected(bool select);
 	/// Allows this button to be toggled on/off with a click.
 	void allowToggleInversion();
 	/// Allows this button to be toggled on when clicked, and off when released.

--- a/src/Interface/BattlescapeButton.h
+++ b/src/Interface/BattlescapeButton.h
@@ -38,7 +38,7 @@ protected:
 	BattlescapeButton **_group, **_groupSelected;
 	bool _inverted, _selected;
 	InversionType _toggleMode;
-    Surface *_altSurface, *_altSurfaceSel, *_altSurfaceInvSel;
+	Surface *_altSurface, *_altSurfaceSel, *_altSurfaceInvSel;
 public:
 	/// Creates a new image button with the specified size and position.
 	BattlescapeButton(int width, int height, int x = 0, int y = 0);
@@ -50,15 +50,15 @@ public:
 	Uint8 getColor() const;
 	/// Sets the image button's group.
 	void setGroup(BattlescapeButton **group);
-    /// Sets the image button's group for _selected.
-    void setGroupSelected(BattlescapeButton **groupSelected);
+	/// Sets the image button's group for _selected.
+	void setGroupSelected(BattlescapeButton **groupSelected);
 	/// Special handling for mouse presses.
 	void mousePress(Action *action, State *state);
 	/// Special handling for mouse releases.
 	void mouseRelease(Action *action, State *state);
 	/// Invert a button explicitly either ON or OFF.
 	void toggle(bool invert);
-    /// Toggle selected either ON or OFF (Extended Reaction Fire, reaction button).
+	/// Toggle selected either ON or OFF (Extended Reaction Fire, reaction button).
 	void toggleSelected(bool select);
 	/// Allows this button to be toggled on/off with a click.
 	void allowToggleInversion();

--- a/src/Interface/BattlescapeButton.h
+++ b/src/Interface/BattlescapeButton.h
@@ -35,10 +35,10 @@ class BattlescapeButton : public InteractiveSurface
 {
 protected:
 	Uint8 _color;
-	BattlescapeButton **_group;
-	bool _inverted;
+	BattlescapeButton **_group, **_groupSelected;
+	bool _inverted, _selected;
 	InversionType _toggleMode;
-	Surface *_altSurface;
+    Surface *_altSurface, *_altSurfaceSel, *_altSurfaceInvSel;
 public:
 	/// Creates a new image button with the specified size and position.
 	BattlescapeButton(int width, int height, int x = 0, int y = 0);
@@ -50,12 +50,16 @@ public:
 	Uint8 getColor() const;
 	/// Sets the image button's group.
 	void setGroup(BattlescapeButton **group);
+    /// Sets the image button's group for _selected.
+    void setGroupSelected(BattlescapeButton **groupSelected);
 	/// Special handling for mouse presses.
 	void mousePress(Action *action, State *state);
 	/// Special handling for mouse releases.
 	void mouseRelease(Action *action, State *state);
 	/// Invert a button explicitly either ON or OFF.
 	void toggle(bool invert);
+    /// Toggle selected either ON or OFF (Extended Reaction Fire, reaction button).
+    void toggleSelected(bool select);
 	/// Allows this button to be toggled on/off with a click.
 	void allowToggleInversion();
 	/// Allows this button to be toggled on when clicked, and off when released.

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -1368,6 +1368,22 @@ bool RuleItem::isExplodingInHands() const
 {
 	return _isExplodingInHands;
 }
+	
+/**
+ *
+ *
+ */
+bool RuleItem::canReact(int type) const
+{
+	switch (type)
+	{
+		case 7: return _canReactAuto;
+		case 8: return _canReactSnap;
+		case 9: return _canReactAimed;
+		case 10: return _canReactMelee;
+		default: return false;
+	}
+}
     
 /**
  * Can this item be used for reactions with aimed shot?

--- a/src/Mod/RuleItem.h
+++ b/src/Mod/RuleItem.h
@@ -388,6 +388,8 @@ public:
 	bool isFireExtinguisher() const;
 	/// Is this item explode in hands?
 	bool isExplodingInHands() const;
+	/// Can the item be used for specified reactions?
+	bool canReact(int type) const;
 	/// Can the item be used for reactions with aimed shot?
 	bool canReactAimed() const;
 	/// Can the item be used for reactions with auto shot?

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -56,7 +56,7 @@ namespace OpenXcom
 BattleUnit::BattleUnit(Soldier *soldier, int depth, int maxViewDistance) :
 	_faction(FACTION_PLAYER), _originalFaction(FACTION_PLAYER), _killedBy(FACTION_PLAYER), _id(0), _tile(0),
 	_lastPos(Position()), _direction(0), _toDirection(0), _directionTurret(0), _toDirectionTurret(0),
-	_verticalDirection(0), _status(STATUS_STANDING), _wantsToSurrender(false), _walkPhase(0), _fallPhase(0), _kneeled(false), _floating(false),
+	_verticalDirection(0), _status(STATUS_STANDING), _wantsToSurrender(false), _walkPhase(0), _fallPhase(0), _kneeled(false), _floating(false), _reservedAction(BA_NONE),
 	_dontReselect(false), _fire(0), _currentAIState(0), _visible(false),
 	_expBravery(0), _expReactions(0), _expFiring(0), _expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0),
 	_motionPoints(0), _kills(0), _hitByFire(false), _fireMaxHit(0), _smokeMaxHit(0), _moraleRestored(0), _coverReserve(0), _charging(0), _turnsSinceSpotted(255),
@@ -381,6 +381,7 @@ void BattleUnit::load(const YAML::Node &node, const ScriptGlobal *shared)
 	_energy = node["energy"].as<int>(_energy);
 	_morale = node["morale"].as<int>(_morale);
 	_kneeled = node["kneeled"].as<bool>(_kneeled);
+	_reservedAction = (BattleActionType)node["reservedAction"].as<int>(_reservedAction);
 	_floating = node["floating"].as<bool>(_floating);
 	for (int i=0; i < SIDE_MAX; i++)
 		_currentArmor[i] = node["armor"][i].as<int>(_currentArmor[i]);
@@ -453,6 +454,7 @@ YAML::Node BattleUnit::save(const ScriptGlobal *shared) const
 	node["morale"] = _morale;
 	node["kneeled"] = _kneeled;
 	node["floating"] = _floating;
+	node["reservedAction"] = (int)_reservedAction;
 	for (int i=0; i < SIDE_MAX; i++) node["armor"].push_back(_currentArmor[i]);
 	for (int i=0; i < BODYPART_MAX; i++) node["fatalWounds"].push_back(_fatalWounds[i]);
 	node["fire"] = _fire;
@@ -1008,6 +1010,24 @@ bool BattleUnit::isFloating() const
 {
 	return _floating;
 }
+	
+/**	 
+ * Is the unit reserving TUs for a reaction shot?
+ * @return the type of action (snap, aimed, auto).
+ */
+BattleActionType BattleUnit::getReservedAction() const
+{
+	return _reservedAction;
+}
+
+/**
+ * Reserve TUs for a reaction shot, for this unit only.
+ * @param the type of action (snap, aimed, auto).
+ */
+void BattleUnit::reserveAction(BattleActionType type)
+ {
+	 _reservedAction = type;
+ }
 
 /**
  * Aim. (shows the right hand sprite and weapon holding)
@@ -4284,6 +4304,7 @@ void BattleUnit::ScriptRegister(ScriptParserBase* parser)
 	bu.add<&getRecolorScript>("getRecolor");
 	bu.add<&BattleUnit::isFloating>("isFloating");
 	bu.add<&BattleUnit::isKneeled>("isKneeled");
+	// FIXME: bu.add<&BattleUnit::getReservedAction>("getReservedAction");
 	bu.add<&isStandingScript>("isStanding");
 	bu.add<&isWalkingScript>("isWalking");
 	bu.add<&isFlyingScript>("isFlying");

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -94,7 +94,7 @@ private:
 	std::unordered_set<Tile *> _visibleTilesLookup;
 	int _tu, _energy, _health, _morale, _stunlevel;
 	bool _kneeled, _floating, _dontReselect;
-    BattleActionType _reservedAction;
+	BattleActionType _reservedAction;
 	int _currentArmor[SIDE_MAX], _maxArmor[SIDE_MAX];
 	int _fatalWounds[BODYPART_MAX];
 	int _fire;

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -94,6 +94,7 @@ private:
 	std::unordered_set<Tile *> _visibleTilesLookup;
 	int _tu, _energy, _health, _morale, _stunlevel;
 	bool _kneeled, _floating, _dontReselect;
+    BattleActionType _reservedAction;
 	int _currentArmor[SIDE_MAX], _maxArmor[SIDE_MAX];
 	int _fatalWounds[BODYPART_MAX];
 	int _fire;
@@ -239,6 +240,10 @@ public:
 	bool isKneeled() const;
 	/// Is floating?
 	bool isFloating() const;
+    /// Get the reserved action.
+    BattleActionType getReservedAction() const;
+    /// Set action for which the individual unit reserves TUs
+    void reserveAction(BattleActionType type);
 	/// Aim.
 	void aim(bool aiming);
 	/// Get direction to a certain point

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -240,10 +240,10 @@ public:
 	bool isKneeled() const;
 	/// Is floating?
 	bool isFloating() const;
-    /// Get the reserved action.
-    BattleActionType getReservedAction() const;
-    /// Set action for which the individual unit reserves TUs
-    void reserveAction(BattleActionType type);
+	/// Get the reserved action.
+	BattleActionType getReservedAction() const;
+	/// Set action for which the individual unit reserves TUs
+	void reserveAction(BattleActionType type);
 	/// Aim.
 	void aim(bool aiming);
 	/// Get direction to a certain point


### PR DESCRIPTION
Added functionality to Extended Reaction Fire: now right click on reserve TU button in battlescape sets an individual preference as to which reaction fire type to use (snap, auto, or aimed). That type will be used if possible and if within minimum reaction range – otherwise revert to automatic selection based on TUs and range. The selection can be set separately to each unit. The choice can be seen by the yellow/gold colour of the figure within the reserve TUs button. Animations, pathfinding and unit properties changed accordingly.